### PR TITLE
Fix critical error on some platforms

### DIFF
--- a/proj/src/tumclient/TumClientApp.cc
+++ b/proj/src/tumclient/TumClientApp.cc
@@ -43,7 +43,8 @@ void TumClientApp::initialize(int stage)
         WATCH(numRequestsToSend);
         WATCH(earlySend);
 
-        istringstream ss{par("tracksToRequest")};
+        const string tracksToRequestParameter = par("tracksToRequest");
+        istringstream ss{tracksToRequestParameter};
         int track_no;
         this->tracksToRequest = vector<int>();
         while (ss >> track_no) {


### PR DESCRIPTION
On my Mac, I cannot compile the program without this change. This likely has to do with compiler versions, but I would include this change just to be safe.